### PR TITLE
wfBaseConvert removed in MediaWiki 1.31

### DIFF
--- a/s3/AmazonS3FileBackend.php
+++ b/s3/AmazonS3FileBackend.php
@@ -180,9 +180,9 @@ class AmazonS3FileBackend extends FileBackendStore {
 		}
 
 		if ( is_resource( $params['content'] ) ) {
-			$sha1Hash = wfBaseConvert( sha1_file( $params['src'] ), 16, 36, 31 );
+			$sha1Hash = Wikimedia\base_convert( sha1_file( $params['src'] ), 16, 36, 31, true, 'auto' );
 		} else {
-			$sha1Hash = wfBaseConvert( sha1( $params['content'] ), 16, 36, 31 );
+			$sha1Hash = Wikimedia\base_convert( sha1( $params['content'] ), 16, 36, 31, true, 'auto' );
 		}
 
 		$params['headers'] = isset( $params['headers'] ) ? $params['headers'] : array();


### PR DESCRIPTION
This will make AWS compatible with 1.31